### PR TITLE
SCL-9: Tests for Scrolls main class are broken

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ dependencies {
         transitive = false // this avoids affecting your version of Groovy/Spock
     }
     testCompile group: 'com.sun.grizzly', name: 'grizzly-comet-webserver', version:'1.9.64'
+    testCompile 'com.github.stefanbirkner:system-rules:1.16.0'
 }
 
 task uberjar(type: Jar, dependsOn:[':compileJava',':compileGroovy']) {


### PR DESCRIPTION
Fixed here by using JUnit rules that help to test System calls (including System.out and System.exit). Although the System.exit rule behavior is strange (not sure if it depends on Groovy or Spock or both). But it works, and the System.out rule is neat.